### PR TITLE
Add coverage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 lib
 node_modules
 build
+**/coverage

--- a/tests/test-datastore/karma.conf.js
+++ b/tests/test-datastore/karma.conf.js
@@ -2,13 +2,17 @@ module.exports = function (config) {
   config.set({
     basePath: '.',
     frameworks: ['mocha'],
-    reporters: ['mocha'],
+    reporters: ['mocha', 'coverage-istanbul'],
     files: ['build/bundle.test.js'],
     port: 9876,
     colors: true,
     singleRun: true,
     browserNoActivityTimeout: 30000,
     failOnEmptyTestSuite: false,
+    coverageIstanbulReporter: {
+      reports: [ 'html', 'text-summary' ],
+      fixWebpackSourcePaths: true,
+    },
     logLevel: config.LOG_INFO
   });
 };

--- a/tests/test-datastore/package.json
+++ b/tests/test-datastore/package.json
@@ -14,8 +14,10 @@
   "devDependencies": {
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
+    "istanbul-instrumenter-loader": "3.0.1",
     "karma": "^1.5.0",
     "karma-chrome-launcher": "^2.0.0",
+    "karma-coverage-istanbul-reporter": "2.0.5",
     "karma-firefox-launcher": "^1.0.0",
     "karma-ie-launcher": "^1.0.0",
     "karma-mocha": "^1.3.0",

--- a/tests/test-datastore/webpack.config.js
+++ b/tests/test-datastore/webpack.config.js
@@ -4,5 +4,15 @@ module.exports = {
   entry: './build/index.spec.js',
   output: {
     filename: './build/bundle.test.js'
+  },
+  module: {
+    rules: [
+      // instrument only testing sources with Istanbul
+      {
+        test: /\.js$/,
+        use: { loader: 'istanbul-instrumenter-loader' },
+        include: path.resolve('../../packages/datastore/')
+      }
+    ]
   }
 }


### PR DESCRIPTION
After you run the datastore tests you can now `open coverage/index.html` to see the coverage results. It unfortunately currently is looking at the JS files instead of the Typescript, but this seems still workable. I looked into trying to pick up source maps generated by typescript, but hit a wall.

<img width="973" alt="Screen Shot 2019-07-08 at 1 24 19 PM" src="https://user-images.githubusercontent.com/1186124/60829775-b6bae480-a183-11e9-8014-b702faae4796.png">
